### PR TITLE
Keep default behaviour for non-numeric keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = input => {
 
 			const index = Number(name);
 
-			return target[index < 0 ? target.length + index : index];
+			return target[index < 0 ? target.length + index : name];
 		},
 		set(target, name, value) {
 			if (typeof name !== 'string') {
@@ -22,7 +22,7 @@ module.exports = input => {
 
 			const index = Number(name);
 
-			target[index < 0 ? target.length + index : index] = value;
+			target[index < 0 ? target.length + index : name] = value;
 
 			return true;
 		}

--- a/test.js
+++ b/test.js
@@ -7,6 +7,10 @@ test('get values', t => {
 	t.is(fixture[1], 'bar');
 	t.is(fixture[-1], 'baz');
 	t.is(fixture[-2], 'bar');
+
+	t.is(fixture.length, 3);
+	t.is(typeof fixture.unknown, 'undefined');
+	t.is(fixture.map, Array.prototype.map);
 });
 
 test('set values', t => {
@@ -31,6 +35,12 @@ test('set values', t => {
 	t.is(fixture[0], 0);
 	t.is(fixture[1], -2);
 	t.is(fixture[2], -1);
+
+	fixture.a = 'a';
+	fixture.b = 'b';
+
+	t.is(fixture.a, 'a');
+	t.is(fixture.b, 'b');
 });
 
 // `t.deepEqual` can't handle Proxy objects:


### PR DESCRIPTION
Keys were being accessed or set as `"NaN"` for non-numeric keys